### PR TITLE
Defines flatpickr bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     ],
     "dependencies": {
         "angular": "^1.3.0",
+        "flatpickr": "^2.6.3",
         "flatpickr-calendar": "^2.0.0"
     }
 }


### PR DESCRIPTION
Need to define the correct dependency version of flatpickr.

Without it being defined a project would not update flatpickr when angular-flatpickr is updated, resulting in the error `FlatpickrInstance is not defined`