### PR TITLE
Updating Bower Deps. to Flatpickr 3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     ],
     "dependencies": {
         "angular": "^1.3.0",
-        "flatpickr": "^2.6.3",
-        "flatpickr-calendar": "^2.0.0"
+        "flatpickr": "^3.0.0"
     }
 }


### PR DESCRIPTION
The angular-flatpickr library is updated to support Flatpickr 3.0 but the bower.json needs to be updated to install it by default