### PR TITLE
Fixed version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,6 @@
     ],
     "dependencies": {
         "angular": "^1.3.0",
-        "flatpickr": "^3.0.0"
+        "flatpickr": "3.0.7"
     }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-flatpickr",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "homepage": "https://github.com/archsaber/angular-flatpickr",
     "authors": [
         "opavader <ashish@archsaber.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-flatpickr",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "angular directive for flatpickr",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
flatpickr did a major change to its lib, but incorrectly set the semver-major so it's now breaking. Setting the version to flatpckr to 3.0.7 fixes this. Changing FlatpickrInstance to flatpckr would be the long-term solution, but this solves the immediate problem.